### PR TITLE
Save didOnboard flag to backend when a user creates an account and completes onboarding

### DIFF
--- a/Pear/Controller/LoginViewController.swift
+++ b/Pear/Controller/LoginViewController.swift
@@ -111,7 +111,6 @@ extension LoginViewController: GIDSignInDelegate {
         }
 
         let onboardingVC = OnboardingPageViewController(transitionStyle: .scroll, navigationOrientation: .horizontal)
-        let onboardingCompleted = UserDefaults.standard.bool(forKey: Constants.UserDefaults.onboardingCompletion)
         let loginVC = LoginViewController()
         var base64Str = ""
         if let idToken = user.authentication.idToken,
@@ -126,10 +125,6 @@ extension LoginViewController: GIDSignInDelegate {
                 base64Str = profileImagePngData.base64EncodedString()
             }
             let userNetId = userEmail[..<userEmail.firstIndex(of: "@")!]
-            UserDefaults.standard.set(userNetId, forKey: Constants.UserDefaults.userNetId)
-            UserDefaults.standard.set(userFirstName, forKey: Constants.UserDefaults.userFirstName)
-            UserDefaults.standard.set(userFullName, forKey: Constants.UserDefaults.userFullName)
-            UserDefaults.standard.set(base64Str, forKey: Constants.UserDefaults.userProfilePictureURL)
             NetworkManager.shared.createUser(idToken: idToken).observe { [weak self] result in
                 guard let self = self else { return }
                 DispatchQueue.main.async {
@@ -138,9 +133,8 @@ extension LoginViewController: GIDSignInDelegate {
                         let userSession = response.data
                         UserDefaults.standard.set(userSession.accessToken, forKey: Constants.UserDefaults.accessToken)
                         UserDefaults.standard.set(userSession.refreshToken, forKey: Constants.UserDefaults.refreshToken)
-                        UserDefaults.standard.set(userSession.sessionExpiration, forKey: Constants.UserDefaults.sessionExpiration)
-                        let vc = onboardingCompleted ? HomeViewController() : onboardingVC
-                        self.navigationController?.pushViewController(vc, animated: false)
+//                        let vc = onboardingCompleted ? HomeViewController() : onboardingVC
+                        self.navigationController?.pushViewController(HomeViewController(), animated: false)
                     case .error:
                         self.present(UIAlertController.getStandardErrortAlert(), animated: true, completion: nil)
                         self.navigationController?.pushViewController(loginVC, animated: false)

--- a/Pear/Models/User.swift
+++ b/Pear/Models/User.swift
@@ -22,7 +22,7 @@ struct User: Codable, Equatable {
     let groups: [String]
     let facebook: String?
     let instagram: String?
-    let didOnboard: Bool?
+    let didOnboard: Bool
 
     static func == (lhs: User, rhs: User) -> Bool {
         return lhs.netID == rhs.netID &&

--- a/Pear/Models/User.swift
+++ b/Pear/Models/User.swift
@@ -10,19 +10,19 @@ import Foundation
 
 struct User: Codable, Equatable {
 
-    let netID: String
-    let firstName: String
-    let lastName: String
-    let hometown: String
-    let profilePictureURL: String
-    let major: String
-    let graduationYear: String
-    let pronouns: String
-    let interests: [String]
-    let groups: [String]
-    let facebook: String?
-    let instagram: String?
     let didOnboard: Bool
+    let graduationYear: String
+    let groups: [String]
+    let hometown: String
+    let facebook: String?
+    let firstName: String
+    let interests: [String]
+    let instagram: String?
+    let lastName: String
+    let major: String
+    let netID: String
+    let profilePictureURL: String
+    let pronouns: String
 
     static func == (lhs: User, rhs: User) -> Bool {
         return lhs.netID == rhs.netID &&

--- a/Pear/Models/User.swift
+++ b/Pear/Models/User.swift
@@ -22,6 +22,7 @@ struct User: Codable, Equatable {
     let groups: [String]
     let facebook: String?
     let instagram: String?
+    let didOnboard: Bool?
 
     static func == (lhs: User, rhs: User) -> Bool {
         return lhs.netID == rhs.netID &&

--- a/Pear/Networking/Body.swift
+++ b/Pear/Networking/Body.swift
@@ -34,9 +34,9 @@ struct UpdateUserTalkingPointsBody: Codable {
 
 struct UpdateUserSocialMediaBody: Codable {
 
+    let didOnboard: Bool
     let facebook: String
     let instagram: String
-    let didOnboard: Bool
 
 }
 

--- a/Pear/Networking/Body.swift
+++ b/Pear/Networking/Body.swift
@@ -36,6 +36,7 @@ struct UpdateUserSocialMediaBody: Codable {
 
     let facebook: String
     let instagram: String
+    let didOnboard: Bool
 
 }
 

--- a/Pear/Networking/Endpoints.swift
+++ b/Pear/Networking/Endpoints.swift
@@ -163,8 +163,8 @@ extension Endpoint {
     }
 
     /// [POST] Update social media information about the user.
-    static func updateUserSocialMedia(facebook: String, instagram: String) -> Endpoint {
-        let body = UpdateUserSocialMediaBody(facebook: facebook, instagram: instagram)
+    static func updateUserSocialMedia(facebook: String, instagram: String, didOnboard: Bool) -> Endpoint {
+        let body = UpdateUserSocialMediaBody(facebook: facebook, instagram: instagram, didOnboard: didOnboard)
         return Endpoint(path: "/user/socialMedia/", headers: standardHeaders, body: body)
     }
 

--- a/Pear/Networking/NetworkManager.swift
+++ b/Pear/Networking/NetworkManager.swift
@@ -139,8 +139,8 @@ class NetworkManager {
     }
 
     /// [POST] Update social media information about the user.
-    func updateUserSocialMedia(facebook: String, instagram: String) -> Future<SuccessResponse> {
-        networking(Endpoint.updateUserSocialMedia(facebook: facebook, instagram: instagram)).decode()
+    func updateUserSocialMedia(facebook: String, instagram: String, didOnboard: Bool) -> Future<SuccessResponse> {
+        networking(Endpoint.updateUserSocialMedia(facebook: facebook, instagram: instagram, didOnboard: didOnboard)).decode()
     }
     
     /// [POST] Update time availabilities of the user.

--- a/Pear/Onboarding/SocialMediaViewController.swift
+++ b/Pear/Onboarding/SocialMediaViewController.swift
@@ -194,6 +194,7 @@ class SocialMediaViewController: UIViewController {
                 switch result {
                 case .value(let response):
                     if response.success {
+                        UserDefaults.standard.set(true, forKey: Constants.UserDefaults.onboardingCompletion)
                         self.navigationController?.pushViewController(HomeViewController(), animated: true)
                     } else {
                         self.present(UIAlertController.getStandardErrortAlert(), animated: true, completion: nil)

--- a/Pear/Onboarding/SocialMediaViewController.swift
+++ b/Pear/Onboarding/SocialMediaViewController.swift
@@ -86,7 +86,7 @@ class SocialMediaViewController: UIViewController {
         skipButton.setTitleColor(.inactiveGreen, for: .normal)
         skipButton.backgroundColor = .none
         skipButton.isEnabled = false
-        skipButton.addTarget(self, action: #selector(skipButtonPressed), for: .touchUpInside)
+        skipButton.addTarget(self, action: #selector(nextButtonPressed), for: .touchUpInside)
         view.addSubview(skipButton)
 
         getUserSocialMedia()
@@ -188,13 +188,12 @@ class SocialMediaViewController: UIViewController {
     @objc func nextButtonPressed() {
         let instagramHandle = instagramTextField.text ?? ""
         let facebookHandle = facebookTextField.text ?? ""
-        NetworkManager.shared.updateUserSocialMedia(facebook: facebookHandle, instagram: instagramHandle).observe { [weak self] result in
+        NetworkManager.shared.updateUserSocialMedia(facebook: facebookHandle, instagram: instagramHandle, didOnboard: true).observe { [weak self] result in
             guard let self = self else { return }
             DispatchQueue.main.async {
                 switch result {
                 case .value(let response):
                     if response.success {
-                        UserDefaults.standard.set(true, forKey: Constants.UserDefaults.onboardingCompletion)
                         self.navigationController?.pushViewController(HomeViewController(), animated: true)
                     } else {
                         self.present(UIAlertController.getStandardErrortAlert(), animated: true, completion: nil)
@@ -229,12 +228,6 @@ class SocialMediaViewController: UIViewController {
                 }
             }
         }
-    }
-
-    @objc func skipButtonPressed() {
-        UserDefaults.standard.set(true, forKey: Constants.UserDefaults.onboardingCompletion)
-        let homeVC = HomeViewController()
-        navigationController?.pushViewController(homeVC, animated: true)
     }
 
 }

--- a/Pear/Onboarding/SocialMediaViewController.swift
+++ b/Pear/Onboarding/SocialMediaViewController.swift
@@ -78,7 +78,7 @@ class SocialMediaViewController: UIViewController {
         nextButton.backgroundColor = .inactiveGreen
         nextButton.layer.cornerRadius = 26
         nextButton.isEnabled = false
-        nextButton.addTarget(self, action: #selector(nextButtonPressed), for: .touchUpInside)
+        nextButton.addTarget(self, action: #selector(completeOnboarding), for: .touchUpInside)
         view.addSubview(nextButton)
 
         skipButton.titleLabel?.font = ._16CircularStdMedium
@@ -86,7 +86,7 @@ class SocialMediaViewController: UIViewController {
         skipButton.setTitleColor(.inactiveGreen, for: .normal)
         skipButton.backgroundColor = .none
         skipButton.isEnabled = false
-        skipButton.addTarget(self, action: #selector(nextButtonPressed), for: .touchUpInside)
+        skipButton.addTarget(self, action: #selector(completeOnboarding), for: .touchUpInside)
         view.addSubview(skipButton)
 
         getUserSocialMedia()
@@ -185,7 +185,7 @@ class SocialMediaViewController: UIViewController {
         delegate?.backPage(index: 4)
     }
 
-    @objc func nextButtonPressed() {
+    @objc func completeOnboarding() {
         let instagramHandle = instagramTextField.text ?? ""
         let facebookHandle = facebookTextField.text ?? ""
         NetworkManager.shared.updateUserSocialMedia(facebook: facebookHandle, instagram: instagramHandle, didOnboard: true).observe { [weak self] result in

--- a/Pear/Settings/EditSocialMediaViewController.swift
+++ b/Pear/Settings/EditSocialMediaViewController.swift
@@ -111,7 +111,7 @@ class EditSocialMediaViewController: UIViewController {
     @objc private func saveSocialMedia() {
         let instagramHandle = instaTextField.text ?? ""
         let facebookHandle = fbTextField.text ?? ""
-        NetworkManager.shared.updateUserSocialMedia(facebook: facebookHandle, instagram: instagramHandle).observe { [weak self] result in
+        NetworkManager.shared.updateUserSocialMedia(facebook: facebookHandle, instagram: instagramHandle, didOnboard: true).observe { [weak self] result in
             guard let self = self else { return }
             DispatchQueue.main.async {
                 switch result {

--- a/Pear/Settings/SettingsViewController.swift
+++ b/Pear/Settings/SettingsViewController.swift
@@ -146,13 +146,8 @@ extension SettingsViewController: UITableViewDataSource {
             pushEditSocialMediaViewController()
         } else if option.text == "Log Out" {
             GIDSignIn.sharedInstance()?.signOut()
-            UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.userNetId)
-            UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.userFirstName)
-            UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.userFullName)
-            UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.userProfilePictureURL)
             UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.accessToken)
             UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.refreshToken)
-            UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.sessionExpiration)
             self.view.window?.rootViewController = UINavigationController(rootViewController: LoginViewController())
             self.view.window?.makeKeyAndVisible()
         }

--- a/Pear/Settings/SettingsViewController.swift
+++ b/Pear/Settings/SettingsViewController.swift
@@ -148,6 +148,7 @@ extension SettingsViewController: UITableViewDataSource {
             GIDSignIn.sharedInstance()?.signOut()
             UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.accessToken)
             UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.refreshToken)
+            UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.onboardingCompletion)
             self.view.window?.rootViewController = UINavigationController(rootViewController: LoginViewController())
             self.view.window?.makeKeyAndVisible()
         }

--- a/Pear/Settings/SettingsViewController.swift
+++ b/Pear/Settings/SettingsViewController.swift
@@ -149,6 +149,8 @@ extension SettingsViewController: UITableViewDataSource {
             UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.accessToken)
             UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.refreshToken)
             UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.onboardingCompletion)
+            UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.userNetId)
+            UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.userProfilePictureURL)
             self.view.window?.rootViewController = UINavigationController(rootViewController: LoginViewController())
             self.view.window?.makeKeyAndVisible()
         }

--- a/Pear/Settings/SettingsViewController.swift
+++ b/Pear/Settings/SettingsViewController.swift
@@ -146,11 +146,12 @@ extension SettingsViewController: UITableViewDataSource {
             pushEditSocialMediaViewController()
         } else if option.text == "Log Out" {
             GIDSignIn.sharedInstance()?.signOut()
-            UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.accessToken)
-            UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.refreshToken)
-            UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.onboardingCompletion)
-            UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.userNetId)
-            UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.userProfilePictureURL)
+            [Constants.UserDefaults.accessToken,
+             Constants.UserDefaults.refreshToken,
+             Constants.UserDefaults.onboardingCompletion,
+             Constants.UserDefaults.userNetId,
+             Constants.UserDefaults.userProfilePictureURL
+            ].forEach(UserDefaults.standard.removeObject(forKey:))
             self.view.window?.rootViewController = UINavigationController(rootViewController: LoginViewController())
             self.view.window?.makeKeyAndVisible()
         }

--- a/Pear/Supporting/Constants.swift
+++ b/Pear/Supporting/Constants.swift
@@ -32,7 +32,6 @@ struct Constants {
         static let accessToken = "accessToken"
         static let onboardingCompletion = "onboardingCompletion"
         static let refreshToken = "refreshToken"
-        static let sessionExpiration = "sessionExpiration"
 
         // User Info
         static let userFirstName = "userFirstName"


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->

Backend recently added `didOnboard` as a field in the `User` object. This PR updates our network requests to reflect this change.


## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->

- After onboarding, we will update the `didOnboard` flag of the user as well as save the value to user defaults
- When a user logs in, we will also make a request to get the user so that we can tell whether the user has onboarded or not

## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

- By hand

